### PR TITLE
Use default export

### DIFF
--- a/module/index.js
+++ b/module/index.js
@@ -1,4 +1,4 @@
-export function expandObjectKeys (obj) {
+export default function expandObjectKeys (obj) {
   if (obj == null) throw new TypeError('expandObjectKeys cannot be called with null or undefined');
 
   const expand = (newObj, key, idx, keys) => {

--- a/readme.md
+++ b/readme.md
@@ -13,7 +13,7 @@ $ npm install --save expand-object-keys
 ## Usage
 
 ```js
-import { expandObjectKeys } from 'expand-object-keys';
+import expandObjectKeys from 'expand-object-keys';
 
 
 const obj = {

--- a/tests/test.js
+++ b/tests/test.js
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import { expandObjectKeys } from '../module';
+import expandObjectKeys from '../module';
 
 describe('expandObjectKeys', () => {
 	it('should Expand dotty object keys to objects', () => {


### PR DESCRIPTION
Node.js modules generally prefer `module.exports` when there is just one thing in a module. Is there any reason not to export `expandObjectKeys` by default?

Or we could support both styles — since this lib is already at 1.0.0:

``` js
expandObjectKeys.expandObjectKeys = expandObjectKeys;
```
